### PR TITLE
Add Forgejo

### DIFF
--- a/flux/apps/hoyeslab/forgejo/README.md
+++ b/flux/apps/hoyeslab/forgejo/README.md
@@ -87,7 +87,9 @@ Then log in at `https://code.hoyes.dev` with the admin credentials. If desired, 
 
 ## Limitations and Future Work
 
-- `replicaCount: 1` is enforced even though the storage layer supports HA. Running multiple replicas needs some additional Forgejo cron configuration to avoid duplicate work, and the chart itself warns against `replicaCount > 1` without those guards.
+- `replicaCount: 1` is enforced even though the storage layer supports HA
+  - The chart itself warns against `replicaCount > 1`
+  - The default indexer used, bleve, does not support HA. We would need to switch to elasticsearch.
 - `externalTrafficPolicy: Local` with a single replica means SSH and HTTPS traffic only land on the node currently running the Forgejo pod. A node failure breaks both until the pod reschedules and MetalLB re-elects. Same property as nginx-ingress today.
 - Forgejo Actions are enabled in the config but no runners are deployed yet. Need to deploy a runner with access to this Forgejo instance and a registration token from the admin UI.
 - The instance is private to my LAN today. To go public, add an Ingress with the `nginx-cloudflare` class (see [ingress-nginx README](/flux/infrastructure/controllers/ingress-nginx/README.md)), put a Cloudflare Access policy in front, and revisit `REQUIRE_SIGNIN_VIEW` and registration settings. Consider adding NetworkPolicies for namespace isolation at that point.

--- a/flux/apps/hoyeslab/forgejo/README.md
+++ b/flux/apps/hoyeslab/forgejo/README.md
@@ -1,0 +1,93 @@
+# Forgejo
+
+This set of manifests deploys [Forgejo](https://forgejo.org/), a self-hosted git forge. It's reachable on my LAN at `https://code.hoyes.dev` (web) and `git@git.hoyes.dev:user/repo.git` (SSH clone). The instance is currently private only via the regular `nginx` ingress class, but it's designed so that exposing it publicly via a Cloudflare tunnel later requires minimal changes.
+
+## Pre-requisites
+
+This setup requires a few things available in the cluster:
+- [CloudNative-PG](https://cloudnative-pg.io/) for managed Postgres ([my deployment](/flux/apps/hoyeslab/database/cloudnative-pg/)), along with the [barman-cloud plugin](/flux/apps/hoyeslab/database/cloudnative-pg/barman-cloud/) for S3 backups.
+- [Dragonfly Operator](https://www.dragonflydb.io/) for a Redis-compatible cache ([my deployment](/flux/apps/hoyeslab/database/dragonfly/)).
+- [MetalLB](https://metallb.io/) (or equivalent) for `LoadBalancer` services.
+- [external-dns](/flux/infrastructure/controllers/external-dns/) configured to watch Services. This is what auto-creates the `git.hoyes.dev` A record from a Service annotation.
+- [cert-manager](/flux/infrastructure/controllers/cert-manager/) with a `letsencrypt` ClusterIssuer for the wildcard `*.hoyes.dev` certificate.
+- An NFS server with an SSD-backed share (see below).
+- [1Password Operator](/flux/infrastructure/foundation/1password/) (or any way of getting an admin user secret into the cluster).
+
+## The Setup
+
+The `forgejo` namespace contains three logical pieces:
+
+- **Postgres** (`postgres/`): a CloudNative-PG `Cluster` with 2 instances on `longhorn-local` (local SSD storage), backed up nightly to versitygw (S3) via the barman-cloud plugin. Postgres 18.
+- **Dragonfly** (`dragonfly/`): a single-replica Redis-compatible cache, used by Forgejo for the cache, queue, and session backends.
+- **Forgejo** (`forgejo/`): the application itself, deployed via the [official Helm chart](https://artifacthub.io/packages/helm/forgejo-helm/forgejo). The PV, PVC, and 1Password secret are managed alongside the `HelmRelease`.
+
+The `kustomization.yaml` at the top of this directory pulls all three together, plus a namespace and a wildcard certificate.
+
+## Storage
+
+Forgejo's `/data` mount holds repositories, LFS objects, attachments, the auto-generated `app.ini`, and SSH host keys. We mount this from the NAS over NFS, specifically from a share which is backed by NVMe SSDs rather than HDDs.
+
+The share is created on my DS920 at `/volume2/data-fast/forgejo`, owned by the `service-access` user (UID 1029, GID 100). NFSv4.1 is enabled in DSM. Squash is disabled, since the pod runs as 1029:100 anyway and we control the only client.
+
+### Why a custom PV instead of an inline `nfs:` volume
+
+Forgejo's documentation [recommends specific mount options for hosted repository data](https://forgejo.org/docs/next/admin/installation/docker/#hosting-repository-data-on-remote-storage-systems), which can't be set with a regular inline `nfs:` volume spec in the pod template:
+
+```
+hard,timeo=10,retry=10,vers=4.1
+```
+
+The `hard` flag in particular blocks all file operations if the share is unavailable, which prevents partial writes from corrupting repositories during a NAS hiccup. Inline `nfs:` volumes don't expose `mountOptions` to the user, so we use a `PersistentVolume` with an explicit `mountOptions` list and a pre-bound `claimRef`.
+
+### Why `ReadWriteMany`
+
+The PV is declared `ReadWriteMany` even though `replicaCount: 1`. This leaves the door open for running Forgejo in HA later without a storage migration. NFS supports concurrent access natively, so the access mode is just a scheduler hint and costs nothing to set.
+
+Forgejo HA also needs an external database (we have it), Redis-backed queue/cache/session (we have it), and some attention to cron jobs that assume single-instance.
+
+## Auto-Generating Signing Keys
+
+Forgejo derives several signing keys on first install: `SECRET_KEY`, `INTERNAL_TOKEN`, `JWT_SECRET`, `LFS_JWT_SECRET`. These encrypt some database fields and sign JWTs for LFS and OAuth.
+
+The Helm chart's [`config_environment.sh` init script](https://code.forgejo.org/forgejo-helm/forgejo-helm/src/tag/v17.1.0/scripts/config_environment.sh) calls `forgejo generate secret <TYPE>` for each of these on first pod start, writes them to `gitea/conf/app.ini` on the NFS share, and then explicitly refuses to overwrite them on subsequent restarts (it detects the existing `app.ini` and unsets the env vars).
+
+We deliberately don't manage these via 1Password. The keys are generated on first run and live in `app.ini` on the NFS share, which is covered by btrfs snapshots and Hyper Backup. Any normal restore (rolling back to a snapshot, restoring from Hyper Backup, recovering after a NAS failure) pulls `app.ini` along with the repositories, so the keys come back with the data.
+
+## SSH Hostname
+
+The web UI is at `https://code.hoyes.dev`. SSH clones use `git@git.hoyes.dev:user/repo.git`, which is necessarily on a different subdomain / IP address.
+
+The Forgejo SSH server runs on port 22 and is exposed via a `LoadBalancer` service. Sharing an IP address with the `nginx-ingress` controller [using MetalLB](https://metallb.universe.tf/usage/#ip-address-sharing) is not possible, since both would need to use `externalTrafficPolicy: Cluster`. We prefer to use `externalTrafficPolicy: Local` to preserve client IPs, hence we need a separate service and load balancer IP address for SSH.
+
+Creating the separate A record is handled by an External DNS annotation on the load balancer service.
+
+## Rootless Image
+
+The Helm chart sets `image.rootless: true` by default and we keep that. The rootless image runs as a non-root user and ships with its own embedded SSH server (not the system OpenSSH), which sidesteps a [documented NFS issue](https://forgejo.org/docs/next/admin/installation/docker/#hosting-repository-data-on-remote-storage-systems) where SSH host key permissions become `0777` over NFS and break standard OpenSSH.
+
+We override the chart's default UID/GID (1000:1000) to `1029:100` via `podSecurityContext` and `containerSecurityContext`, matching the `service-access` user on the NAS so files on the NFS share have consistent ownership with everything else.
+
+## Bootstrap
+
+Before applying, the following needs to exist:
+
+1. The NFS share `/volume2/data-fast/forgejo` on the NAS, owned by `1029:100`, exported with NFSv4.1 enabled and "No mapping" squash.
+2. A 1Password item for admin credentials at `vaults/Infrastructure/items/forgejo admin` with fields named exactly:
+    - `username`
+    - `password`
+    - `email`
+3. The 1Password item for the CloudNative-PG S3 credentials for backups (`vaults/Infrastructure/items/cloudnative-pg Versity Gateway`)
+
+After Flux reconciles, give it a few minutes:
+- The CNPG cluster bootstraps two instances.
+- The Forgejo init container generates the initial `app.ini` and writes it to the NFS share.
+- external-dns creates the `git.hoyes.dev` A record within its sync interval (a minute or two).
+
+Then log in at `https://code.hoyes.dev` with the admin credentials. If desired, create a new user account for regular use.
+
+## Limitations and Future Work
+
+- `replicaCount: 1` is enforced even though the storage layer supports HA. Running multiple replicas needs some additional Forgejo cron configuration to avoid duplicate work, and the chart itself warns against `replicaCount > 1` without those guards.
+- `externalTrafficPolicy: Local` with a single replica means SSH and HTTPS traffic only land on the node currently running the Forgejo pod. A node failure breaks both until the pod reschedules and MetalLB re-elects. Same property as nginx-ingress today.
+- Forgejo Actions are enabled in the config but no runners are deployed yet. Need to deploy a runner with access to this Forgejo instance and a registration token from the admin UI.
+- The instance is private to my LAN today. To go public, add an Ingress with the `nginx-cloudflare` class (see [ingress-nginx README](/flux/infrastructure/controllers/ingress-nginx/README.md)), put a Cloudflare Access policy in front, and revisit `REQUIRE_SIGNIN_VIEW` and registration settings. Consider adding NetworkPolicies for namespace isolation at that point.

--- a/flux/apps/hoyeslab/forgejo/certificate.yaml
+++ b/flux/apps/hoyeslab/forgejo/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hoyes-dev-tls
+  namespace: forgejo
+spec:
+  secretName: hoyes-dev-tls
+  dnsNames:
+    - "hoyes.dev"
+    - "*.hoyes.dev"
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer

--- a/flux/apps/hoyeslab/forgejo/dragonfly/cluster.yaml
+++ b/flux/apps/hoyeslab/forgejo/dragonfly/cluster.yaml
@@ -1,0 +1,24 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: forgejo-dragonfly
+  namespace: forgejo
+spec:
+  replicas: 1
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+
+  args:
+    # Each IO thread requires 256 MiB of memory, so we are limited to 2 threads
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 512Mi

--- a/flux/apps/hoyeslab/forgejo/dragonfly/kustomization.yaml
+++ b/flux/apps/hoyeslab/forgejo/dragonfly/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml

--- a/flux/apps/hoyeslab/forgejo/forgejo/kustomization.yaml
+++ b/flux/apps/hoyeslab/forgejo/forgejo/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pv.yaml
+  - secret.yaml
+  - repository.yaml
+  - release.yaml

--- a/flux/apps/hoyeslab/forgejo/forgejo/pv.yaml
+++ b/flux/apps/hoyeslab/forgejo/forgejo/pv.yaml
@@ -1,0 +1,41 @@
+# Using a PV for the forgejo NFS mount to have control over the mount options. See:
+# https://forgejo.org/docs/next/admin/installation/docker/#hosting-repository-data-on-remote-storage-systems
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: forgejo-data
+  labels:
+    app.kubernetes.io/name: forgejo
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - hard
+    - timeo=10
+    - retry=10
+    - vers=4.1
+  nfs:
+    server: ds920.hoyes.dev
+    # NVMe-backed volume
+    path: /volume2/data-fast/forgejo
+  claimRef:
+    namespace: forgejo
+    name: forgejo-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: forgejo-data
+  namespace: forgejo
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 100Gi
+  volumeName: forgejo-data

--- a/flux/apps/hoyeslab/forgejo/forgejo/release.yaml
+++ b/flux/apps/hoyeslab/forgejo/forgejo/release.yaml
@@ -147,6 +147,11 @@ spec:
         actions:
           ENABLED: true
 
+        # See https://forgejo.org/docs/latest/admin/config-cheat-sheet/#indexer-indexer
+        # The default indexer type (bleve) is not compatible with HA
+        indexer:
+          REPO_INDEXER_ENABLED: true
+
     resources:
       requests:
         cpu: 100m

--- a/flux/apps/hoyeslab/forgejo/forgejo/release.yaml
+++ b/flux/apps/hoyeslab/forgejo/forgejo/release.yaml
@@ -1,0 +1,156 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  releaseName: forgejo
+  interval: 10m
+  chart:
+    spec:
+      chart: forgejo
+      version: 17.1.0
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: forgejo
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 1
+    strategy:
+      type: Recreate
+
+    image:
+      rootless: true
+      pullPolicy: IfNotPresent
+
+    # Run as DS920 service-access user (1029:100) for NFS share
+    podSecurityContext:
+      fsGroup: 100
+    containerSecurityContext:
+      runAsUser: 1029
+      runAsGroup: 100
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - SETGID
+          - SETUID
+      seccompProfile:
+        type: RuntimeDefault
+
+    persistence:
+      enabled: true
+      # We provide our own NFS-backed PV+PVC (see pv.yaml)
+      create: false
+      claimName: forgejo-data
+
+    service:
+      ssh:
+        type: LoadBalancer
+        port: 22
+        externalTrafficPolicy: Local
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: git.hoyes.dev
+
+    ingress:
+      enabled: true
+      className: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: 1024m
+      hosts:
+        - host: code.hoyes.dev
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - hosts:
+            - code.hoyes.dev
+          secretName: hoyes-dev-tls
+
+    # Bootstrap the admin user from 1Password
+    gitea:
+      admin:
+        existingSecret: forgejo-admin
+        passwordMode: keepUpdated
+
+      additionalConfigFromEnvs:
+        # Database credentials from CNPG-managed secret
+        - name: FORGEJO__database__USER
+          valueFrom:
+            secretKeyRef:
+              name: forgejo-pg18-app
+              key: username
+        - name: FORGEJO__database__PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: forgejo-pg18-app
+              key: password
+        - name: FORGEJO__database__NAME
+          valueFrom:
+            secretKeyRef:
+              name: forgejo-pg18-app
+              key: dbname
+
+      config:
+        APP_NAME: "Forgejo: hoyeslab"
+        RUN_MODE: prod
+
+        server:
+          DOMAIN: code.hoyes.dev
+          ROOT_URL: https://code.hoyes.dev/
+          SSH_DOMAIN: git.hoyes.dev
+          SSH_PORT: 22
+          SSH_LISTEN_PORT: 2222
+          DISABLE_SSH: false
+          START_SSH_SERVER: true
+          LFS_START_SERVER: true
+
+        database:
+          DB_TYPE: postgres
+          HOST: forgejo-pg18-rw:5432
+          SSL_MODE: require
+
+        cache:
+          ADAPTER: redis
+          HOST: redis://forgejo-dragonfly:6379/0
+
+        session:
+          PROVIDER: redis
+          PROVIDER_CONFIG: redis://forgejo-dragonfly:6379/1
+
+        queue:
+          TYPE: redis
+          CONN_STR: redis://forgejo-dragonfly:6379/2
+
+        security:
+          INSTALL_LOCK: true
+          PASSWORD_HASH_ALGO: argon2
+
+        service:
+          DISABLE_REGISTRATION: true
+          REQUIRE_SIGNIN_VIEW: false
+          DEFAULT_KEEP_EMAIL_PRIVATE: true
+
+        repository:
+          DEFAULT_BRANCH: main
+          DEFAULT_PRIVATE: private
+
+        log:
+          LEVEL: info
+
+        actions:
+          ENABLED: true
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 1Gi

--- a/flux/apps/hoyeslab/forgejo/forgejo/repository.yaml
+++ b/flux/apps/hoyeslab/forgejo/forgejo/repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: forgejo
+  namespace: flux-system
+spec:
+  interval: 1h
+  type: oci
+  url: oci://code.forgejo.org/forgejo-helm

--- a/flux/apps/hoyeslab/forgejo/forgejo/secret.yaml
+++ b/flux/apps/hoyeslab/forgejo/forgejo/secret.yaml
@@ -1,0 +1,11 @@
+# Requires keys (chart's gitea.admin.existingSecret format):
+#   - username
+#   - password
+#   - email
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: forgejo-admin
+  namespace: forgejo
+spec:
+  itemPath: "vaults/Infrastructure/items/forgejo admin"

--- a/flux/apps/hoyeslab/forgejo/ks.yaml
+++ b/flux/apps/hoyeslab/forgejo/ks.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./flux/apps/hoyeslab/forgejo
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: infrastructure-configs
+    - name: dragonflydb
+    - name: cloudnative-pg

--- a/flux/apps/hoyeslab/forgejo/kustomization.yaml
+++ b/flux/apps/hoyeslab/forgejo/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - certificate.yaml
+  - dragonfly/
+  - postgres/
+  - forgejo/

--- a/flux/apps/hoyeslab/forgejo/namespace.yaml
+++ b/flux/apps/hoyeslab/forgejo/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo

--- a/flux/apps/hoyeslab/forgejo/postgres/cluster.yaml
+++ b/flux/apps/hoyeslab/forgejo/postgres/cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: forgejo-pg18
+  namespace: forgejo
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3-standard-trixie
+
+  enableSuperuserAccess: true
+
+  storage:
+    storageClass: longhorn-local
+    size: 5Gi
+
+  bootstrap:
+    initdb:
+      database: forgejo
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: versitygw
+        serverName: forgejo-pg18-001

--- a/flux/apps/hoyeslab/forgejo/postgres/kustomization.yaml
+++ b/flux/apps/hoyeslab/forgejo/postgres/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - s3-secret.yaml
+  - objectstore.yaml
+  - cluster.yaml
+  - scheduledbackup.yaml

--- a/flux/apps/hoyeslab/forgejo/postgres/objectstore.yaml
+++ b/flux/apps/hoyeslab/forgejo/postgres/objectstore.yaml
@@ -1,0 +1,22 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: versitygw
+  namespace: forgejo
+spec:
+  retentionPolicy: 7d
+  configuration:
+    data:
+      compression: gzip
+    wal:
+      compression: gzip
+      maxParallel: 8
+    destinationPath: s3://cloudnative-pg/forgejo/
+    endpointURL: https://versitygw.hoyes.dev
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-s3
+        key: access_key
+      secretAccessKey:
+        name: cloudnative-pg-s3
+        key: secret_key

--- a/flux/apps/hoyeslab/forgejo/postgres/s3-secret.yaml
+++ b/flux/apps/hoyeslab/forgejo/postgres/s3-secret.yaml
@@ -1,0 +1,10 @@
+# Requires keys:
+#   - access_key
+#   - secret_key
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudnative-pg-s3
+  namespace: forgejo
+spec:
+  itemPath: "vaults/Infrastructure/items/cloudnative-pg Versity Gateway"

--- a/flux/apps/hoyeslab/forgejo/postgres/scheduledbackup.yaml
+++ b/flux/apps/hoyeslab/forgejo/postgres/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: forgejo-backup
+  namespace: forgejo
+spec:
+  schedule: '0 0 2 * * *'
+  backupOwnerReference: self
+  cluster:
+    name: forgejo-pg18
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/flux/apps/hoyeslab/kustomization.yaml
+++ b/flux/apps/hoyeslab/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - pihole/ks.yaml
   - paperless/ks.yaml
   - home-automation/ks.yaml
+  - forgejo/ks.yaml


### PR DESCRIPTION
Adds Forgejo

For storage:
- Data storage is over NFS to a new `data-fast` volume which is backed by NVMe
- Postgres 18 database via CNPG
- Redis via Dragonfly operator

See the included readme in the Forgejo folder for more details