### PR TITLE
Enable Versity Gateway Web UI

### DIFF
--- a/docker/versity-gateway/.gitignore
+++ b/docker/versity-gateway/.gitignore
@@ -1,1 +1,1 @@
-.config/
+config/

--- a/docker/versity-gateway/README.md
+++ b/docker/versity-gateway/README.md
@@ -15,6 +15,34 @@ Since my data is backed by a Synology NAS that only supports NFS 4.1 (xattrs sup
 3. Optionally change `ROOT_ACCESS_KEY` (the username)
 4. Set `ADMIN_SECRET_KEY` to the same value as `ROOT_SECRET_KEY` to simplify running admin commands in the container
 
+### Reverse Proxy
+
+Versity Gateway can be deployed behind a reverse proxy for both admin and S3 operations. I used Synology's built-in reverse proxy (Control Panel > Login Portal > Advanced > Reverse Proxy) to set up the following proxies (all hostnames resolve to local IPs):
+
+- S3: `https://s3.hoyes.dev` to `http://localhost:7070`.
+- Admin API: `https://versitygw-admin.hoyes.dev` to `http://localhost:7071` (port from `VGW_ADMIN_PORT`)
+- Web UI: `https://versitygw.hoyes.dev` to `http://localhost:7072` (port from `VGW_WEBUI_PORT`)
+
+Use discretion if exposing to the public internet.
+
+### Web UI
+
+In addition to the S3 interface, Versity Gateway provides an Admin API and Web UI. The web UI requires access to the admin UI, so both must be exposed and accessible.
+
+When using a custom domain, the hostnames for the S3 endpoint, Admin API, and Web UI must be provided to the container:
+
+```yaml
+environment:
+  # S3 URLs for the Web UI
+  VGW_WEBUI_GATEWAYS: "https://s3.hoyes.dev"
+  # Admin API URL
+  VGW_WEBUI_ADMIN_GATEWAYS: "https://versitygw-admin.hoyes.dev"
+  # Web UI URL, for CORS
+  VGW_CORS_ALLOW_ORIGIN: "https://versitygw.hoyes.dev"
+```
+
+All CLI management commands described below can be performed through the Web UI as well.
+
 ### Managing Users
 
 The service is configured to use an internal IAM directory, where user accounts are stored in a `users.json` file. The contents of this file are stored in plaintext, so it isn't the most secure option. Consider using the Vault or LDAP IAM options if security is a concern. In my case, this simple setup just serves to limit bucket access for connecting services.
@@ -37,7 +65,7 @@ myuser2  user      0       0
 To run from a different host, change the `ADMIN_ENDPOINT_URL` environment variable or specify one with `--endpoint-url`:
 
 ```shell
-docker compose run --rm versitygw admin --endpoint-url https://versitygw.hoyes.dev list-users
+docker compose run --rm versitygw admin --endpoint-url https://s3.hoyes.dev list-users
 ```
 
 #### Creating Users
@@ -58,12 +86,6 @@ To reassign an existing bucket to a different user:
 docker compose exec versitygw /app/versitygw admin change-bucket-owner --bucket <bucket> --owner <user>
 ```
 
-### Reverse Proxy
-
-As demonstrated in the examples above, Versity Gateway can be deployed behind a reverse proxy for both admin and S3 operations. I used Synology's built-in reverse proxy (Control Panel > Login Portal > Advanced > Reverse Proxy) to proxy `https://versitygw.hoyes.dev` (which resolves to a local IP address) to `http://localhost:7070`.
-
-Use discretion if exposing to the public internet.
-
 ## Creating Buckets
 
 The `versitygw` CLI cannot create or delete buckets and objects. For that, we need the `aws` CLI.
@@ -74,11 +96,11 @@ To create a bucket, either the root user or a user with the `userplus` role is r
  export AWS_ACCESS_KEY_ID=versitygw  # Root user or user with `userplus` role
  export AWS_SECRET_ACCESS_KEY=<secret_key>
 
-aws --endpoint-url https://versitygw.hoyes.dev s3 mb s3://my_bucket
+aws --endpoint-url https://s3.hoyes.dev s3 mb s3://my_bucket
 ```
 
 To delete a bucket, again using either the root user or a `userplus` role:
 
 ```shell
-aws --endpoint-url https://versitygw.hoyes.dev s3 rb s3://my_bucket --force
+aws --endpoint-url https://s3.hoyes.dev s3 rb s3://my_bucket --force
 ```

--- a/docker/versity-gateway/compose.yaml
+++ b/docker/versity-gateway/compose.yaml
@@ -2,15 +2,23 @@ services:
   versitygw:
     image: ghcr.io/versity/versitygw:v1.4.1
     restart: always
-    command: >-
-      --iam-dir /config
-      posix
-      /data/buckets
-      --versioning-dir /data/versions
-      --bucketlinks
     ports:
       - "7070:7070"
+      - "7071:7071"
+      - "7072:7072"
     volumes:
       - /volume1/object_storage/versitygw:/data
       - ./config:/config
+    # Secret keys
     env_file: .env
+    environment:
+      VGW_IAM_DIR: /config
+      VGW_BACKEND: posix
+      VGW_BACKEND_ARGS: /data/buckets
+      VGW_VERSIONING_DIR: /data/versions
+      VGW_BUCKET_LINKS: "true"
+      VGW_ADMIN_PORT: ":7071"
+      VGW_WEBUI_PORT: ":7072"
+      VGW_WEBUI_ADMIN_GATEWAYS: "https://versitygw-admin.hoyes.dev"
+      VGW_WEBUI_GATEWAYS: "https://s3.hoyes.dev"
+      VGW_CORS_ALLOW_ORIGIN: "https://versitygw.hoyes.dev"

--- a/flux/apps/hoyeslab/forgejo/postgres/objectstore.yaml
+++ b/flux/apps/hoyeslab/forgejo/postgres/objectstore.yaml
@@ -12,7 +12,7 @@ spec:
       compression: gzip
       maxParallel: 8
     destinationPath: s3://cloudnative-pg/forgejo/
-    endpointURL: https://versitygw.hoyes.dev
+    endpointURL: https://s3.hoyes.dev
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-s3

--- a/flux/apps/hoyeslab/paperless/postgres/objectstore.yaml
+++ b/flux/apps/hoyeslab/paperless/postgres/objectstore.yaml
@@ -12,7 +12,7 @@ spec:
       compression: gzip
       maxParallel: 8
     destinationPath: s3://cloudnative-pg/paperless/
-    endpointURL: https://versitygw.hoyes.dev
+    endpointURL: https://s3.hoyes.dev
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-s3


### PR DESCRIPTION
Enables the Versity Gateway admin and web endpoints

S3 operations are now served behind `s3.hoyes.dev`, and `versitygw.hoyes.dev` serves the web UI.

Reverse proxy for all (`s3`, `versitygw-admin`, and `versitygw.hoyes.dev`) are configured through Synology's reverse proxy with CNAMEs to `ds920.hoyes.dev` for consistency instead of using the external-services chart and proxying through kubernetes.

Closes #206 