### PR TITLE
Tune NFS settings for qbittorrent

### DIFF
--- a/flux/apps/hoyeslab/media/jellyfin/deployment.yaml
+++ b/flux/apps/hoyeslab/media/jellyfin/deployment.yaml
@@ -84,9 +84,8 @@ spec:
             claimName: jellyfin-config
         # Media volume is an NFS share
         - name: jellyfin-media
-          nfs:
-            server: ds920.hoyes.dev
-            path: /volume1/media
+          persistentVolumeClaim:
+            claimName: media
         # Transcode volume is an emptyDir. Could make in-memory if desired.
         - name: jellyfin-transcode
           emptyDir: {}

--- a/flux/apps/hoyeslab/media/kustomization.yaml
+++ b/flux/apps/hoyeslab/media/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - certificate.yaml
+  - pv.yaml
   - jellyfin/ks.yaml
   - seerr/ks.yaml
   - qbittorrent/ks.yaml

--- a/flux/apps/hoyeslab/media/pv.yaml
+++ b/flux/apps/hoyeslab/media/pv.yaml
@@ -1,0 +1,54 @@
+# Shared PV/PVC for the /volume1/media DS920 NFS export, consumed by qbittorrent, radarr,
+# sonarr, and jellyfin. We use a static PV (instead of inline `spec.volumes.nfs`) so
+# we can control the mount options.
+#
+# NFS transport options (nconnect/rsize/wsize) are negotiated on the first mount to a
+# server on each node and reused by subsequent mounts. So every consumer of this export
+# must mount with the same options for them to be effective and consistent - hence a
+# single shared PV referenced by all media apps.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: media
+  labels:
+    app.kubernetes.io/name: media
+spec:
+  # Capacity is not enforced for NFS, but required on the PV/PVC spec nonetheless. We
+  # don't need to change this if the NAS gets more storage.
+  capacity:
+    storage: 36Ti
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+    - noatime
+    # Open multiple TCP connections to the NAS for better throughput
+    - nconnect=4
+    # Larger read/write sizes for media I/O (1Mi). The client negotiates down if the
+    # server won't honor them. Synology's NFS UI lets you specify up to 32 KB as the
+    # default size, but it can negotiate higher to 128 KiB in practice.
+    - rsize=1048576
+    - wsize=1048576
+  nfs:
+    server: ds920.hoyes.dev
+    path: /volume1/media
+  claimRef:
+    namespace: media
+    name: media
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: media
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 36Ti
+  volumeName: media

--- a/flux/apps/hoyeslab/media/qbittorrent/configmap.yaml
+++ b/flux/apps/hoyeslab/media/qbittorrent/configmap.yaml
@@ -17,13 +17,14 @@ data:
     Session\DisableAutoTMMByDefault=false
     Session\DisableAutoTMMTriggers\CategorySavePathChanged=false
     Session\DisableAutoTMMTriggers\DefaultSavePathChanged=false
+    Session\DiskIOType=Posix
     Session\Interface=tun0
     Session\InterfaceName=tun0
     Session\MaxActiveDownloads=20
     Session\MaxActiveTorrents=30
     Session\MaxActiveUploads=10
     Session\Encryption=1
-    Session\Preallocation=true
+    Session\Preallocation=false
     Session\QueueingSystemEnabled=false
     Session\ShareLimitAction=Stop
     Session\TorrentContentLayout=Original

--- a/flux/apps/hoyeslab/media/qbittorrent/deployment.yaml
+++ b/flux/apps/hoyeslab/media/qbittorrent/deployment.yaml
@@ -217,6 +217,5 @@ spec:
           persistentVolumeClaim:
             claimName: prowlarr-config
         - name: media
-          nfs:
-            server: ds920.hoyes.dev
-            path: /volume1/media
+          persistentVolumeClaim:
+            claimName: media

--- a/flux/apps/hoyeslab/media/radarr/deployment.yaml
+++ b/flux/apps/hoyeslab/media/radarr/deployment.yaml
@@ -66,6 +66,5 @@ spec:
         # Mount the entire media share so radarr can hard link
         # from /data/torrents/ to /data/media/movies/
         - name: media
-          nfs:
-            server: ds920.hoyes.dev
-            path: /volume1/media
+          persistentVolumeClaim:
+            claimName: media

--- a/flux/apps/hoyeslab/media/sonarr/deployment.yaml
+++ b/flux/apps/hoyeslab/media/sonarr/deployment.yaml
@@ -66,6 +66,5 @@ spec:
         # Mount the entire media share so sonarr can hard link
         # from /data/torrents/ to /data/media/tv/
         - name: media
-          nfs:
-            server: ds920.hoyes.dev
-            path: /volume1/media
+          persistentVolumeClaim:
+            claimName: media


### PR DESCRIPTION
Tunes the NFS settings for qBittorrent

The default behaviour in qBittorrent 5.2 / libtorrent 2.0 is to use mmap disk IO. When the disk is over NFS and the application is running on a VM without swap space, this resulted in a massive OOM (700+ GB).

Changes:
- Disk IO type changed to Posix in the default configmap, and for running instance via settings
- Pre-allocation disabled in the default configmap and via settings
- Tweaked the NFS mount settings: nconnect=4 (multiple TCP connections), set a larger rsize/wsize though Synology will negotiate these to 128 KB anyway most likely
  - Moved the NFS mount to a single PV/PVC shared by all media applications