### PR TITLE
Add Open WebUI

### DIFF
--- a/flux/apps/hoyeslab/kustomization.yaml
+++ b/flux/apps/hoyeslab/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - paperless/ks.yaml
   - home-automation/ks.yaml
   - forgejo/ks.yaml
+  - openwebui/ks.yaml

--- a/flux/apps/hoyeslab/openwebui/certificate.yaml
+++ b/flux/apps/hoyeslab/openwebui/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hoyes-dev-tls
+  namespace: openwebui
+spec:
+  secretName: hoyes-dev-tls
+  dnsNames:
+    - "hoyes.dev"
+    - "*.hoyes.dev"
+  issuerRef:
+    name: letsencrypt
+    kind: ClusterIssuer

--- a/flux/apps/hoyeslab/openwebui/dragonfly/cluster.yaml
+++ b/flux/apps/hoyeslab/openwebui/dragonfly/cluster.yaml
@@ -1,0 +1,24 @@
+apiVersion: dragonflydb.io/v1alpha1
+kind: Dragonfly
+metadata:
+  name: openwebui-dragonfly
+  namespace: openwebui
+spec:
+  replicas: 1
+  env:
+    - name: MAX_MEMORY
+      valueFrom:
+        resourceFieldRef:
+          resource: limits.memory
+          divisor: 1Mi
+
+  args:
+    # Each IO thread requires 256 MiB of memory, so we are limited to 2 threads
+    - --maxmemory=$(MAX_MEMORY)Mi
+    - --proactor_threads=2
+
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 512Mi

--- a/flux/apps/hoyeslab/openwebui/dragonfly/kustomization.yaml
+++ b/flux/apps/hoyeslab/openwebui/dragonfly/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml

--- a/flux/apps/hoyeslab/openwebui/ks.yaml
+++ b/flux/apps/hoyeslab/openwebui/ks.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: openwebui
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./flux/apps/hoyeslab/openwebui
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: infrastructure-configs
+    - name: dragonflydb
+    - name: cloudnative-pg

--- a/flux/apps/hoyeslab/openwebui/kustomization.yaml
+++ b/flux/apps/hoyeslab/openwebui/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - certificate.yaml
+  - dragonfly/
+  - postgres/
+  - openwebui/

--- a/flux/apps/hoyeslab/openwebui/namespace.yaml
+++ b/flux/apps/hoyeslab/openwebui/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openwebui

--- a/flux/apps/hoyeslab/openwebui/openwebui/kustomization.yaml
+++ b/flux/apps/hoyeslab/openwebui/openwebui/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pv.yaml
+  - secret.yaml
+  - repository.yaml
+  - release.yaml

--- a/flux/apps/hoyeslab/openwebui/openwebui/pv.yaml
+++ b/flux/apps/hoyeslab/openwebui/openwebui/pv.yaml
@@ -1,0 +1,42 @@
+# SSD NFS-backed PV for Open WebUI's data dir (/app/backend/data).
+# Contains upload source documents and the embedding-model cache.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: openwebui-data
+  labels:
+    app.kubernetes.io/name: open-webui
+spec:
+  capacity:
+    # Capacity is ignored for NFS mounts, but needs to be set anyway
+    storage: 20Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - hard
+    - timeo=10
+    - retry=10
+    - vers=4.1
+  nfs:
+    server: ds920.hoyes.dev
+    # NVMe-backed volume
+    path: /volume2/data-fast/openwebui
+  claimRef:
+    namespace: openwebui
+    name: openwebui-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-data
+  namespace: openwebui
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 20Gi
+  volumeName: openwebui-data

--- a/flux/apps/hoyeslab/openwebui/openwebui/release.yaml
+++ b/flux/apps/hoyeslab/openwebui/openwebui/release.yaml
@@ -33,13 +33,18 @@ spec:
     # Lemonade does not require auth, this is a placeholder the OpenAI client needs
     openaiApiKey: "none"
 
-    # Run as DS920 service-access user (1029:100) for NFS share
+    # The default image only supports running as root, since it writes to some in-container
+    # directories. We could build our own image in the future, see:
+    # https://docs.openwebui.com/getting-started/advanced-topics/hardening/#non-root-execution
+    # For now, we still set the GID so files on the NFS share are owned by the users group.
+    # The user will still be root (uid 0), the group will be users (100).
     podSecurityContext:
       fsGroup: 100
     containerSecurityContext:
-      runAsUser: 1029
+      # Un-comment these if we switch to rootless
+      # runAsUser: 1029
+      # runAsNonRoot: true
       runAsGroup: 100
-      runAsNonRoot: true
       allowPrivilegeEscalation: false
 
     # NFS-backed data dir (uploads + embedding-model cache), see pv.yaml
@@ -89,14 +94,6 @@ spec:
 
       - name: CORS_ALLOW_ORIGIN
         value: "https://chat.hoyes.dev"
-
-      # The default HOME is /root, which won't be writeable by the 1029:100
-      # user we're running as for NFS access. There shouldn't be any significant
-      # writes there for cache, but redirect it to the NFS mount just in case.
-      - name: HOME
-        value: /app/backend/data
-      - name: PYTHONDONTWRITEBYTECODE
-        value: "1"
 
       # Opt out of telemetry/analytics
       - name: ANONYMIZED_TELEMETRY

--- a/flux/apps/hoyeslab/openwebui/openwebui/release.yaml
+++ b/flux/apps/hoyeslab/openwebui/openwebui/release.yaml
@@ -1,0 +1,115 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: open-webui
+  namespace: openwebui
+spec:
+  releaseName: open-webui
+  interval: 10m
+  chart:
+    spec:
+      chart: open-webui
+      version: 14.8.0
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: open-webui
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  values:
+    replicaCount: 1
+
+    # Models hosted via Lemonade on my Framework Desktop
+    ollama:
+      enabled: false
+    pipelines:
+      enabled: false
+
+    # Lemonade runs as a systemd service on my Framework Desktop. Won't always be available,
+    # but can be woken on LAN from Home Assistant if needed.
+    openaiBaseApiUrl: "http://192.168.2.13:13305/api/v1"
+    # Lemonade does not require auth, this is a placeholder the OpenAI client needs
+    openaiApiKey: "none"
+
+    # Run as DS920 service-access user (1029:100) for NFS share
+    podSecurityContext:
+      fsGroup: 100
+    containerSecurityContext:
+      runAsUser: 1029
+      runAsGroup: 100
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+
+    # NFS-backed data dir (uploads + embedding-model cache), see pv.yaml
+    persistence:
+      enabled: true
+      existingClaim: openwebui-data
+
+    # DATABASE_URL is injected from the CNPG-managed secret below
+    databaseUrl: ""
+
+    # Websocket coordination via the Dragonfly instance
+    websocket:
+      enabled: true
+      manager: redis
+      url: "redis://openwebui-dragonfly:6379/0"
+      redis:
+        # Use our Dragonfly, not the chart's bundled redis
+        enabled: false
+
+    ingress:
+      enabled: true
+      class: nginx
+      annotations:
+        # Allow larger document uploads
+        nginx.ingress.kubernetes.io/proxy-body-size: 1024m
+      host: chat.hoyes.dev
+      tls: true
+      existingSecret: hoyes-dev-tls
+
+    extraEnvVars:
+      # Database connection string from the CNPG-managed app secret. The `uri` key
+      # is a full postgresql://user:pass@openwebui-pg18-rw:5432/openwebui URL.
+      - name: DATABASE_URL
+        valueFrom:
+          secretKeyRef:
+            name: openwebui-pg18-app
+            key: uri
+      - name: VECTOR_DB
+        value: pgvector
+
+      # Secret key for sessions and encryption (see secret.yaml)
+      - name: WEBUI_SECRET_KEY
+        valueFrom:
+          secretKeyRef:
+            name: openwebui
+            key: secret_key
+
+      - name: CORS_ALLOW_ORIGIN
+        value: "https://chat.hoyes.dev"
+
+      # The default HOME is /root, which won't be writeable by the 1029:100
+      # user we're running as for NFS access. There shouldn't be any significant
+      # writes there for cache, but redirect it to the NFS mount just in case.
+      - name: HOME
+        value: /app/backend/data
+      - name: PYTHONDONTWRITEBYTECODE
+        value: "1"
+
+      # Opt out of telemetry/analytics
+      - name: ANONYMIZED_TELEMETRY
+        value: "false"
+      - name: SCARF_NO_ANALYTICS
+        value: "true"
+      - name: DO_NOT_TRACK
+        value: "true"
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi

--- a/flux/apps/hoyeslab/openwebui/openwebui/repository.yaml
+++ b/flux/apps/hoyeslab/openwebui/openwebui/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: open-webui
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://helm.openwebui.com/

--- a/flux/apps/hoyeslab/openwebui/openwebui/secret.yaml
+++ b/flux/apps/hoyeslab/openwebui/openwebui/secret.yaml
@@ -1,0 +1,9 @@
+# Requires keys:
+#   - secret_key
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: openwebui
+  namespace: openwebui
+spec:
+  itemPath: "vaults/Infrastructure/items/open-webui"

--- a/flux/apps/hoyeslab/openwebui/postgres/cluster.yaml
+++ b/flux/apps/hoyeslab/openwebui/postgres/cluster.yaml
@@ -1,0 +1,32 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: openwebui-pg18
+  namespace: openwebui
+spec:
+  # Single instance, with the caveat that data is node-local so there's no HA.
+  # Data can be restored from the barman cloud backup in the event of full node failure.
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie
+
+  enableSuperuserAccess: true
+
+  storage:
+    storageClass: longhorn-local
+    size: 10Gi
+
+  bootstrap:
+    initdb:
+      database: openwebui
+      # Open WebUI stores its RAG embeddings in pgvector (VECTOR_DB=pgvector).
+      # pgvector is available in the standard CNPG image, we just need to create
+      # the extension.
+      postInitApplicationSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector;
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: versitygw
+        serverName: openwebui-pg18-001

--- a/flux/apps/hoyeslab/openwebui/postgres/kustomization.yaml
+++ b/flux/apps/hoyeslab/openwebui/postgres/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - s3-secret.yaml
+  - objectstore.yaml
+  - cluster.yaml
+  - scheduledbackup.yaml

--- a/flux/apps/hoyeslab/openwebui/postgres/objectstore.yaml
+++ b/flux/apps/hoyeslab/openwebui/postgres/objectstore.yaml
@@ -1,0 +1,22 @@
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: versitygw
+  namespace: openwebui
+spec:
+  retentionPolicy: 7d
+  configuration:
+    data:
+      compression: gzip
+    wal:
+      compression: gzip
+      maxParallel: 8
+    destinationPath: s3://cloudnative-pg/openwebui/
+    endpointURL: https://s3.hoyes.dev
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-s3
+        key: access_key
+      secretAccessKey:
+        name: cloudnative-pg-s3
+        key: secret_key

--- a/flux/apps/hoyeslab/openwebui/postgres/s3-secret.yaml
+++ b/flux/apps/hoyeslab/openwebui/postgres/s3-secret.yaml
@@ -1,0 +1,10 @@
+# Requires keys:
+#   - access_key
+#   - secret_key
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudnative-pg-s3
+  namespace: openwebui
+spec:
+  itemPath: "vaults/Infrastructure/items/cloudnative-pg Versity Gateway"

--- a/flux/apps/hoyeslab/openwebui/postgres/scheduledbackup.yaml
+++ b/flux/apps/hoyeslab/openwebui/postgres/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: openwebui-backup
+  namespace: openwebui
+spec:
+  schedule: '0 0 2 * * *'
+  backupOwnerReference: self
+  cluster:
+    name: openwebui-pg18
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io


### PR DESCRIPTION
Adds Open WebUI

Deployment notes:
- Uses postgres via CNPG with pgvector as the vector store (and regular application DB). pgvector is installed in the default CNPG images, just need to `CREATE EXTENSION pgvector` as part of the init process
- Uses dragonfly for redis features
- Data (uploaded documents for RAG and cache) is stored on the NAS on an NVMe volume via NFS.
  - Ideally we would run the application as 1029:100 (service-access:users) to match FS permissions with the other deployment, but for now the Open WebUI image doesn't support rootless so it's running as 0:100